### PR TITLE
CartTest.txt: add drmdmp64_mass version string based on git revision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ latex
 /examples/*/*/build*
 test_old/
 tests_obsolete/
+/build/version.h
 _build
 /examples/*/*/ses
 /examples/*/*/ozone

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,32 @@ endif()
 
 add_executable(${PROJECT})
 
+#########################
+## Version information ##
+#########################
+# Credit: https://github.com/mwpenny/portal64-still-alive
+
+set(GEN_VERSION_HEADER "${PROJECT_SOURCE_DIR}/GenVersionHeader.cmake")
+set(VERSION_H          "${PROJECT_BINARY_DIR}/version.h")
+
+add_custom_target(version_header
+    DEPENDS
+        ${GEN_VERSION_HEADER}
+    BYPRODUCTS
+        ${VERSION_H}
+    COMMAND
+        ${CMAKE_COMMAND}
+        -D Git_EXECUTABLE=${Git_EXECUTABLE}
+        -D OUTPUT_FILE=${VERSION_H}
+        -P ${GEN_VERSION_HEADER}
+    WORKING_DIRECTORY
+        ${PROJECT_SOURCE_DIR}
+    VERBATIM
+)
+
+# Make sure version header is always up to date
+add_dependencies(${PROJECT} version_header)
+
 add_custom_command(OUTPUT ${CMAKE_CURRENT_LIST_DIR}/src/generated/joybus.pio.h
         DEPENDS ${CMAKE_CURRENT_LIST_DIR}/src/joybus.pio
         COMMAND pioasm/pioasm ${CMAKE_CURRENT_LIST_DIR}/src/joybus.pio ${CMAKE_CURRENT_LIST_DIR}/src/generated/joybus.pio.h

--- a/GenVersionHeader.cmake
+++ b/GenVersionHeader.cmake
@@ -1,0 +1,44 @@
+#################################
+## Get current project version ##
+#################################
+
+# First try getting the version from git
+execute_process(
+    COMMAND
+        ${Git_EXECUTABLE} describe --tags --always HEAD
+    RESULT_VARIABLE
+        GIT_DESCRIBE_RC
+    OUTPUT_VARIABLE
+        GIT_DESCRIBE_OUTPUT
+)
+
+# If not in a git repo, fall back to exported version
+if (NOT GIT_DESCRIBE_RC EQUAL 0)
+    file(READ version.txt GIT_DESCRIBE_OUTPUT)
+endif()
+
+# Extract the version
+string(STRIP "${GIT_DESCRIBE_OUTPUT}" GIT_DESCRIBE_OUTPUT)
+string(REPLACE "-" ";" GIT_DESCRIBE_COMPONENTS "${GIT_DESCRIBE_OUTPUT}")
+
+list(LENGTH GIT_DESCRIBE_COMPONENTS COMPONENT_COUNT)
+if (COMPONENT_COUNT GREATER_EQUAL 3)
+    # Tags exist and we are not on one. Use commit hash (trim the "g" prefix).
+    list(GET GIT_DESCRIBE_COMPONENTS 2 PROJ_VERSION)
+    string(SUBSTRING "${PROJ_VERSION}" 1 -1 PROJ_VERSION)
+else()
+    # On a git tag, or no tags exist and we only have a hash.
+    # Either way the raw output is appropriate. Use it.
+    list(GET GIT_DESCRIBE_COMPONENTS 0 PROJ_VERSION)
+endif()
+
+file(CONFIGURE
+    OUTPUT ${OUTPUT_FILE}
+    CONTENT
+"#ifndef __PROJ_VERSION_H__
+#define __PROJ_VERSION_H__
+
+#define PROJ_VERSION \"${PROJ_VERSION}\"
+
+#endif"
+)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,23 @@
 include ../../make.mk
 
+# Untested: if for some reason CMake cannot be used, below is the native Makefile equivalent
+# Credit: https://github.com/mwpenny/portal64-still-alive
+# Use tag name if the current commit is tagged, otherwise use commit hash
+# If not in a git repo, fall back to exported version
+#PROJ_VERSION := $(shell \
+#  (git describe --tags HEAD 2>/dev/null || cat version.txt) | \
+#  awk -F '-' '{print (NF >= 3 ? substr($$3, 2) : $$1)}' \
+#)
+#
+# Allow targets to depend on the PROJ_VERSION variable via a file.
+# Update the file only when it differs from the variable (triggers rebuild).
+#.PHONY: gameversion
+#build/version.txt: gameversion
+#ifneq ($(shell cat build/version.txt 2>/dev/null), $(PROJ_VERSION))
+#  echo -n $(PROJ_VERSION) > build/version.txt
+#endif
+
+
 INC += \
 	src \
 	$(TOP)/hw \

--- a/src/virtualdisk.c
+++ b/src/virtualdisk.c
@@ -14,6 +14,8 @@
 #include "tusb.h"
 #include "n64cartinterface.h"
 
+#include "version.h"
+
 #if CFG_TUD_MSC
 
 // whether host does safe-eject
@@ -34,7 +36,8 @@ uint8_t CartTestText[2 * 1024] =
 "    Romsize   - 16MB\n"
 "    RomName   - Placeholder\n"
 "    RomID     - 00000000\n"
-"    RomRegion - Europe\n";
+"    RomRegion - Europe\n"
+"    DrmDmp64m - 00000000\n";
 
 #define vd_sector_count() SECTOR_COUNT
 enum
@@ -315,6 +318,7 @@ uint32_t msc_get_serial_number32() {
 
 #define min(x, y) (x < y ? x : y)
 static volatile uint32_t lock = 0;
+const char* DrmDmp64MassVersion = PROJ_VERSION;
 int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buf, uint32_t buf_size)
 {
     (void)lun;
@@ -525,7 +529,8 @@ int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buf,
                         "    RomID      - %04X %c%c\n"
                         "    CartType   - %c\n"
                         "    RomRegion  - %c\n"
-                        "    RomVersion - %02X\n",
+                        "    RomVersion - %02X\n"
+                        "    DrmDmp64m  - %s\n",
                         EepString,
                         (gSRAMPresent != 0) ? OK : NotPresent,
                         (gFramPresent != 0) ? OK : NotPresent, gFlashType,
@@ -536,7 +541,8 @@ int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buf,
                         gGameCode[1], ((gGameCode[1] >> 8) & 0xFF), (gGameCode[1] & 0xFF),
                         gGameCode[0] & 0xFF,
                         ((gGameCode[2] >> 8) & 0xFF),
-                        (gGameCode[2] & 0xFF)
+                        (gGameCode[2] & 0xFF),
+                        DrmDmp64MassVersion
                         );
                       } else {
                         memset(buf, 0, SECTOR_SIZE);

--- a/version.txt
+++ b/version.txt
@@ -1,0 +1,1 @@
+$Format:%(describe:tags)$


### PR DESCRIPTION
This feature was liberally borrowed from https://github.com/mwpenny/portal64-still-alive 