### PR TITLE
Notepad UTF-16 file fix

### DIFF
--- a/src/joybus.c
+++ b/src/joybus.c
@@ -55,7 +55,7 @@ void __time_critical_func(InitEepromClock)(uint clockpin)
 
     pio_gpio_init(pio_1, clockpin);
 
-    uint offset_1 = pio_add_program(pio_1, &joybus_program);
+    uint offset_1 = (uint)pio_add_program(pio_1, &joybus_program);
     pio_sm_config config1 = joybus_program_get_default_config(offset_1);
     //sm_config_set_out_pins(&config1, clockpin, 1);
     sm_config_set_set_pins(&config1, clockpin, 1);
@@ -101,7 +101,7 @@ void __time_critical_func(InitEeprom)(uint dataPin)
 
     pio_gpio_init(pio, dataPin);
 
-    piooffset = pio_add_program(pio, &joybus_program);
+    piooffset = (uint)pio_add_program(pio, &joybus_program);
     config = joybus_program_get_default_config(piooffset);
     sm_config_set_in_pins(&config, dataPin);
     sm_config_set_out_pins(&config, dataPin, 1);

--- a/src/virtualdisk.c
+++ b/src/virtualdisk.c
@@ -514,7 +514,7 @@ int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buf,
                           CICString = NTSC;
                         }
 
-                        sprintf(buf,
+                        int utf16fix = sprintf(buf,
                         "\nCart tester report:\n\n"
                         "    EEPROM     - %s\n"
                         "    SRAM       - %s\n"
@@ -538,6 +538,9 @@ int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buf,
                         ((gGameCode[2] >> 8) & 0xFF),
                         (gGameCode[2] & 0xFF)
                         );
+                        if (utf16fix % 2 != 0) {
+                          memset(buf + utf16fix, 0x20, 1);
+                        };
                       } else {
                         memset(buf, 0, SECTOR_SIZE);
                       }


### PR DESCRIPTION
This fixes a problem with modern versions of Notepad where it will try to read the file as UTF16 if the null-terminating character after the sprintf text in CartTest.txt is at an even position.

I've also made a change in joybus to get rid of the uint conversion warnings.